### PR TITLE
Include PyPi and downloads badges in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASReview-wordcloud
 
-![Deploy and release](https://github.com/asreview/asreview-wordcloud/workflows/Deploy%20and%20release/badge.svg) ![Build status](https://github.com/asreview/asreview-wordcloud/workflows/test-suite/badge.svg) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4672242.svg)](https://doi.org/10.5281/zenodo.4672242)
+[![PyPI version](https://badge.fury.io/py/asreview-wordcloud.svg)](https://badge.fury.io/py/asreview-wordcloud) [![Downloads](https://pepy.tech/badge/asreview-wordcloud)](https://pepy.tech/project/asreview-wordcloud) ![Deploy and release](https://github.com/asreview/asreview-wordcloud/workflows/Deploy%20and%20release/badge.svg) ![Build status](https://github.com/asreview/asreview-wordcloud/workflows/test-suite/badge.svg) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4672242.svg)](https://doi.org/10.5281/zenodo.4672242)
 
 
 This is a wordcloud supplemental package for the


### PR DESCRIPTION
This PR includes the PyPi and number of downloads badges. Adding the badges helps with visibility of the package and therefore increase traffic.